### PR TITLE
add closing div for footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,5 +180,6 @@
             <a href="https://github.com/transmissions11/transmissions11.github.io"/>t11s' fork</a> of the
             <a href="https://github.com/dapphub/dapp-tools"/>dapptools</a> website</i></p>
       <br />
+    </div>
   </body>
 </html>


### PR DESCRIPTION
Copied your footer style with t11s fork and noticed there's no closing tag for the id="footer" div.